### PR TITLE
Add a mixin and filter for automatically serializing things as JSON.

### DIFF
--- a/herring/puzzles/models.py
+++ b/herring/puzzles/models.py
@@ -23,8 +23,10 @@ def to_json_value(field):
         return field
     if isinstance(field, dict):
         return field
-    if isinstance(field, list) or isinstance(field, models.query.QuerySet):
+    if isinstance(field, (list, models.query.QuerySet)):
         return [to_json_value(item) for item in field]
+    if isinstance(field, models.manager.Manager):
+        return [to_json_value(item) for item in field.all()]
     if isinstance(field, JSONMixin):
         return field.to_json()
 
@@ -39,7 +41,7 @@ class Round(models.Model,JSONMixin):
     class Meta:
         ordering = ['number']
     class Json:
-        include_fields = ['name', 'number']
+        include_fields = ['name', 'number', 'puzzle_set']
 
 
 class Puzzle(models.Model,JSONMixin):
@@ -55,7 +57,7 @@ class Puzzle(models.Model,JSONMixin):
     class Meta:
         ordering = ['parent', '-is_meta', 'number']
     class Json:
-        include_fields = ['parent', 'name', 'number', 'answer', 'note', 'tags', 'is_meta']
+        include_fields = ['name', 'number', 'answer', 'note', 'tags', 'is_meta']
 
     def __str__(self):
         child_type = 'P'

--- a/herring/puzzles/templates/puzzles/index.html
+++ b/herring/puzzles/templates/puzzles/index.html
@@ -32,11 +32,6 @@
 	    <p>No puzzles are available.</p>
 	{% endif %}
 <pre>
-{% for round in rounds %}
-{{ round | to_json }}
-{% for puzzle in round.puzzle_set.all %}
-  {{ puzzle | to_json }}
-{% endfor %}
-{% endfor %}
+{{ rounds | to_json }}
 </pre>
 {% endblock %}

--- a/herring/puzzles/templates/puzzles/index.html
+++ b/herring/puzzles/templates/puzzles/index.html
@@ -1,4 +1,5 @@
 {% extends "puzzles/base.html" %}
+{% load to_json %}
 
 {% block content %}
 	{% if rounds %}
@@ -30,4 +31,12 @@
 	{% else %}
 	    <p>No puzzles are available.</p>
 	{% endif %}
+<pre>
+{% for round in rounds %}
+{{ round | to_json }}
+{% for puzzle in round.puzzle_set.all %}
+  {{ puzzle | to_json }}
+{% endfor %}
+{% endfor %}
+</pre>
 {% endblock %}

--- a/herring/puzzles/templatetags/to_json.py
+++ b/herring/puzzles/templatetags/to_json.py
@@ -7,5 +7,5 @@ from puzzles.models import to_json_value
 register = template.Library()
 
 @register.filter(name='to_json')
-def to_json(field):
-    return json.dumps(to_json_value(field))
+def to_json(data):
+    return json.dumps(to_json_value(data))

--- a/herring/puzzles/templatetags/to_json.py
+++ b/herring/puzzles/templatetags/to_json.py
@@ -1,0 +1,11 @@
+import json
+
+from django import template
+
+from puzzles.models import to_json_value
+
+register = template.Library()
+
+@register.filter(name='to_json')
+def to_json(field):
+    return json.dumps(to_json_value(field))


### PR DESCRIPTION
See usage example in `index.html`.  Consider setting initial values for JS variables with this approach.

Want more fields?  Fewer fields?  The changes in `models.py` are probably self-explanatory.
