### PR TITLE
Add an auto-generated slug per puzzle

### DIFF
--- a/herring/puzzles/models.py
+++ b/herring/puzzles/models.py
@@ -1,11 +1,15 @@
 from django.conf import settings
 from django.db import models
+from autoslug import AutoSlugField
+from puzzles.slugtools import puzzle_to_slug, arbitrary_slug
+
 
 # **optional shortcut for optional fields
 optional = {
     'blank': True,
     'null': True
 }
+
 
 # A mixin class which adds a to_json method to a model
 class JSONMixin(object):
@@ -16,6 +20,7 @@ class JSONMixin(object):
             value = to_json_value(field)
             retval[fieldName] = value
         return retval
+
 
 def to_json_value(field):
     if isinstance(field, str):
@@ -30,6 +35,7 @@ def to_json_value(field):
         return [to_json_value(item) for item in field.all()]
     if isinstance(field, JSONMixin):
         return field.to_json()
+
 
 class Round(models.Model,JSONMixin):
     # shell model for defining rounds
@@ -50,6 +56,11 @@ class Puzzle(models.Model,JSONMixin):
     # class for all puzzles, including metas
     parent = models.ForeignKey(Round)
     name = models.CharField(max_length=200)
+    slug = AutoSlugField(
+        populate_from=puzzle_to_slug,
+        unique=True,
+        db_index=True
+    )
     number = models.IntegerField(**optional)
     answer = models.CharField(max_length=200, default='', **optional)
     note = models.CharField(max_length=200, default='', **optional)
@@ -60,18 +71,23 @@ class Puzzle(models.Model,JSONMixin):
 
     class Meta:
         ordering = ['parent', '-is_meta', 'number']
+
     class Json:
         include_fields = ['id', 'name', 'number', 'answer', 'note', 'tags', 'is_meta', 'url', 'hunt_url']
 
-    def __str__(self):
+    def identifier(self):
         child_type = 'P'
         if self.is_meta:
             child_type = 'M'
-        num = str(self.number) if self.number is not None else '?'
-        return self.parent.__str__() + child_type + num + ': ' + self.name
+        num = str(self.number) if self.number is not None else 'x'
+        return str(self.parent) + child_type + num
+    
+    def __str__(self):
+        return '#%s %s' % (self.slug, self.name)
 
     def is_answered(self):
         return bool(self.answer)
+
 
 class UserProfile(models.Model):
     user = models.OneToOneField(
@@ -80,5 +96,6 @@ class UserProfile(models.Model):
             related_name='profile',
     )
     avatar_url = models.CharField(max_length=200)
+
     def __str__(self):
         return "profile for " + self.user.__str__()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ django-toolbelt==0.0.1
 gunicorn==19.4.5
 natsort==3.5.2
 psycopg2==2.6.1
-pyOpenSSL==0.13
+pyOpenSSL==0.15
 requests==2.8.1
 static3==0.6.1
 urllib3==1.12
+django-autoslug


### PR DESCRIPTION
I believe we're going to need this to connect puzzles with chat channels.

Each puzzle now gets a short slug such as "r4p9-anagrams", auto-generated from the title, skipping some uninformative words.

It would be great if the slug were editable but that would require hacking some JS into the Django admin, as far as I can tell.

Also I bumped the version of pyOpenSSL so I could install herring.
